### PR TITLE
Feature/ping tool

### DIFF
--- a/jabber.csproj
+++ b/jabber.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ESI.NET" Version="2.7.6" />
+    <PackageReference Include="ESI.NET" Version="2.13.13" />
     <PackageReference Include="Matrix.vNext" Version="2.2.0" />
     <PackageReference Include="Matrix.vNext.Extensions" Version="2.2.0" />
     <PackageReference Include="Matrix.vNext.Srv" Version="2.2.0" />

--- a/src/Broadcast.cs
+++ b/src/Broadcast.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using jabber;
+using Jabber;
+
+namespace Jabber
+{
+    public static class Broadcast
+    {
+        /// <summary>
+        /// Pings all people in a channel
+        /// </summary>
+        /// <remarks>Only works in channel: fcincursions</remarks>
+        public static async void All(Command cmd)
+        {
+            if (cmd.XmppMessage.From.User == "fcincursions")
+            {
+                var res = JabberClient.Instance.GetJidsInRoom(cmd.XmppMessage.From.User);
+                List<string> names = new List<string>();
+
+                foreach (var kvp in res)
+                {
+                    if (!names.Contains(kvp.Value.User))
+                        names.Add(kvp.Value.User);
+                }
+
+                await JabberClient.Instance.SendGroupMessage(cmd.XmppMessage.From.Bare, String.Join(" ", names));
+            }
+        }
+
+        /// <summary>
+        /// Pings bot admins in the requestors channel
+        /// </summary>
+        public static async void ToLeadership(Command cmd)
+        {
+            Users users = Users.Get();
+            List<string> names = new List<string>();
+
+            foreach (User user in users.GetAdmins())
+            {
+                names.Add(user.JabberResource);
+            }
+
+            await JabberClient.Instance.SendGroupMessage(cmd.XmppMessage.From.Bare, String.Join(" ", names));
+        }
+
+        /// <summary>
+        /// Pings the FCs who are active in the fcincursions channel
+        /// </summary>
+        public static async void ToFcs(Command cmd)
+        {
+            var active_fcs = JabberClient.Instance.GetJidsInRoom("fcincursions");
+            List<string> names = new List<string>();
+
+            foreach (var kvp in active_fcs)
+            {
+                if (!names.Contains(kvp.Value.User))
+                    names.Add(kvp.Value.User);
+            }
+
+            await JabberClient.Instance.SendGroupMessage(cmd.XmppMessage.From.Bare, String.Join(" ", names));
+        }
+    }
+}

--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -33,6 +33,29 @@ namespace Jabber
 
             // Returns a list of available commands.
             CommandDispatcher.Instance.RegisterCommand("!ihelp", Help);
+
+            CommandDispatcher.Instance.RegisterCommand("!iping", Test);
+        }
+
+        public static async Task Test(Command cmd)
+        {
+            var who = cmd.XmppMessage.From;
+
+            if (cmd.XmppMessage.From.User == "fcincursions")
+            {
+                var res = JabberClient.Instance.GetJidsInRoom(cmd.XmppMessage.From.User);
+                List<string> names = new List<string>();
+
+                foreach(var kvp in res)
+                {
+                    if (!names.Contains(kvp.Value.User))
+                    {
+                        names.Add(kvp.Value.User);
+                    }
+                }
+
+                await JabberClient.Instance.SendGroupMessage(cmd.XmppMessage.From.Bare, String.Join(" ", names));
+            }
         }
 
         public static async Task GetInstructions(Command cmd)

--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -41,20 +41,25 @@ namespace Jabber
         {
             var who = cmd.XmppMessage.From;
 
-            if (cmd.XmppMessage.From.User == "fcincursions")
+            string target = cmd.Args.Trim().ToLower();
+            if (target == "all")
+                Broadcast.All(cmd);
+
+            if (target == "fc")
+                Broadcast.ToFcs(cmd);
+
+            if (target == "leadership")
+                Broadcast.ToLeadership(cmd);
+
+            string response = string.Format("Invalid ping target. |  Syntax !iping {{target}} | Available targets: {0} {1} {2}\nNot all targets will be available.", "fc", "leadership", "");
+
+            if (cmd.XmppMessage.IsGroupMessage())
             {
-                var res = JabberClient.Instance.GetJidsInRoom(cmd.XmppMessage.From.User);
-                List<string> names = new List<string>();
-
-                foreach(var kvp in res)
-                {
-                    if (!names.Contains(kvp.Value.User))
-                    {
-                        names.Add(kvp.Value.User);
-                    }
-                }
-
-                await JabberClient.Instance.SendGroupMessage(cmd.XmppMessage.From.Bare, String.Join(" ", names));
+                await JabberClient.Instance.SendGroupMessage(who.Bare, response);
+            }
+            else
+            {
+                await JabberClient.Instance.SendMessage(who.Bare, response);
             }
         }
 

--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -34,10 +34,10 @@ namespace Jabber
             // Returns a list of available commands.
             CommandDispatcher.Instance.RegisterCommand("!ihelp", Help);
 
-            CommandDispatcher.Instance.RegisterCommand("!iping", Test);
+            CommandDispatcher.Instance.RegisterCommand("!iping", Ping);
         }
 
-        public static async Task Test(Command cmd)
+        public static async Task Ping(Command cmd)
         {
             var who = cmd.XmppMessage.From;
 

--- a/src/Incursions.cs
+++ b/src/Incursions.cs
@@ -44,12 +44,9 @@ namespace Jabber
             // run the UpdateIncursions method.
             if(m_lastChecked == DateTime.MinValue || m_lastChecked.AddMinutes(5) < DateTime.UtcNow)
             {
-                Console.Beep();
                 await UpdateIncursions();
                 m_lastChecked = DateTime.UtcNow;
-                
             }
-
         }
 
         /// <summary>

--- a/src/JabberClient.cs
+++ b/src/JabberClient.cs
@@ -260,5 +260,10 @@ namespace Jabber
                 m_rooms[jid] = existing;
             }
         }
+
+        internal object GetJidsInRoom(object user)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/JabberClient.cs
+++ b/src/JabberClient.cs
@@ -260,10 +260,5 @@ namespace Jabber
                 m_rooms[jid] = existing;
             }
         }
-
-        internal object GetJidsInRoom(object user)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/JabberClient.cs
+++ b/src/JabberClient.cs
@@ -224,6 +224,19 @@ namespace Jabber
             return null;
         }
 
+        public Dictionary<string, Jid> GetJidsInRoom(string room = "incursion_bot_testing")
+        {
+            foreach (var kvp in m_rooms)
+            {
+                if(kvp.Key == room)
+                {
+                    return kvp.Value.m_resourcesToJids;
+                }
+            }
+
+            return null;
+        }
+
         private void TrackPresenceForRooms(Presence p)
         {
             foreach(var kvp in m_rooms)

--- a/src/Users.cs
+++ b/src/Users.cs
@@ -119,6 +119,11 @@ namespace jabber
             }
         }
 
+        /// <summary>
+        /// Returns a list of users who have the admin permission
+        /// </summary>
+        /// <returns>A list of admins</returns>
+        /// <see cref="User"/>
         public List<User> GetAdmins()
         {
             List<User> admins = new List<User>();

--- a/src/Users.cs
+++ b/src/Users.cs
@@ -118,6 +118,19 @@ namespace jabber
                 return string.Format("{0} was not a listed user and could not be removed.", jabber_resource);
             }
         }
+
+        public List<User> GetAdmins()
+        {
+            List<User> admins = new List<User>();
+
+            foreach(KeyValuePair<string, User> u in m_usersList)
+            {
+                if (u.Value.Role == "Admin")
+                    admins.Add(u.Value);
+            }
+
+            return admins;
+        }
     }
 
     internal class User


### PR DESCRIPTION
Added broadcasts commands to the bot for the following targets:

- All - Only works in the `fcincursions` channel as we want to avoid use of this in the wrong channels. This has been hard coded as the name of the channel will not change.
- FCs - Get's a list of the people online in `fcincursions` and pings them in the channel that the `!iping fc` command was used. 
- Leadership - Get's a list of the bot admins and pings them in the channel that the `!iping leadership` 
 command is used. 
